### PR TITLE
refactor(openbb): unify runtime resolution and retry handling

### DIFF
--- a/scripts/_openbb_common.sh
+++ b/scripts/_openbb_common.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Shared runtime helpers for OpenBB wrapper scripts.
+
+resolve_openbb_python() {
+    if [[ -n "${OPENBB_PYTHON:-}" ]]; then
+        if [[ -x "${OPENBB_PYTHON}" ]]; then
+            printf "%s\n" "${OPENBB_PYTHON}"
+            return 0
+        fi
+        echo "OPENBB_PYTHON is set but not executable: ${OPENBB_PYTHON}" >&2
+        return 1
+    fi
+
+    local venv_python="${HOME}/.local/venvs/openbb/bin/python3"
+    if [[ -x "${venv_python}" ]]; then
+        printf "%s\n" "${venv_python}"
+        return 0
+    fi
+
+    if command -v python3 >/dev/null 2>&1; then
+        command -v python3
+        return 0
+    fi
+
+    echo "No usable python3 found for OpenBB wrappers." >&2
+    return 1
+}
+
+setup_openbb_ld_library_path() {
+    local parts=()
+
+    if command -v nix-build >/dev/null 2>&1; then
+        local libstdcpp=""
+        local libz=""
+        libstdcpp="$(nix-build -E "with import <nixpkgs> {}; stdenv.cc.cc.lib" --no-out-link 2>/dev/null || true)"
+        libz="$(nix-build -E "with import <nixpkgs> {}; zlib" --no-out-link 2>/dev/null || true)"
+
+        if [[ -n "${libstdcpp}" && -d "${libstdcpp}/lib" ]]; then
+            parts+=("${libstdcpp}/lib")
+        fi
+        if [[ -n "${libz}" && -d "${libz}/lib" ]]; then
+            parts+=("${libz}/lib")
+        fi
+    fi
+
+    if (( ${#parts[@]} > 0 )); then
+        local joined=""
+        joined="$(IFS=:; echo "${parts[*]}")"
+        export LD_LIBRARY_PATH="${joined}${LD_LIBRARY_PATH:+:${LD_LIBRARY_PATH}}"
+    fi
+}
+
+is_openbb_lock_contention() {
+    local text="$1"
+    [[ "${text}" == *".build.lock"* ]] \
+        || [[ "${text}" == *"Another build process is running"* ]] \
+        || [[ "${text}" == *"BlockingIOError"* ]] \
+        || [[ "${text}" == *"Resource temporarily unavailable"* ]]
+}
+
+run_openbb_python_with_retry() {
+    local script=""
+    script="$(cat)"
+
+    local py=""
+    py="$(resolve_openbb_python)" || return 1
+    setup_openbb_ld_library_path
+
+    local max_attempts="${OPENBB_RETRY_MAX_ATTEMPTS:-6}"
+    local base_delay_sec="${OPENBB_RETRY_BASE_DELAY_SEC:-2}"
+
+    local attempt=1
+    while true; do
+        local output=""
+        local status=0
+
+        if output="$("${py}" 2>&1 <<<"${script}")"; then
+            status=0
+        else
+            status=$?
+        fi
+
+        if [[ ${status} -eq 0 ]]; then
+            printf "%s\n" "${output}"
+            return 0
+        fi
+
+        if is_openbb_lock_contention "${output}"; then
+            if [[ ${attempt} -ge ${max_attempts} ]]; then
+                {
+                    echo "OpenBB wrapper failed after ${max_attempts} lock-contention retries."
+                    echo "${output}"
+                } >&2
+                return "${status}"
+            fi
+
+            local delay=$((base_delay_sec * (2 ** (attempt - 1))))
+            echo "OpenBB build lock detected, retry ${attempt}/${max_attempts} in ${delay}s..." >&2
+            sleep "${delay}"
+            attempt=$((attempt + 1))
+            continue
+        fi
+
+        printf "%s\n" "${output}" >&2
+        return "${status}"
+    done
+}

--- a/scripts/openbb-dividend
+++ b/scripts/openbb-dividend
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 # OpenBB dividend analysis tool
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/_openbb_common.sh"
+
 
 if [ $# -lt 1 ]; then
     echo "Usage: openbb-dividend SYMBOL"
@@ -7,11 +13,7 @@ if [ $# -lt 1 ]; then
 fi
 
 export SYMBOL="$1"
-LIBSTDCXX=$(nix-build -E "with import <nixpkgs> {}; stdenv.cc.cc.lib" --no-out-link 2>/dev/null)/lib
-LIBZ=$(nix-build -E "with import <nixpkgs> {}; zlib" --no-out-link 2>/dev/null)/lib
-export LD_LIBRARY_PATH="$LIBSTDCXX:$LIBZ:${LD_LIBRARY_PATH:-}"
-
-/home/art/.local/venvs/openbb/bin/python3 << 'PYEOF'
+run_openbb_python_with_retry << 'PYEOF'
 import os
 import sys
 import json

--- a/scripts/openbb-earnings
+++ b/scripts/openbb-earnings
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 # OpenBB earnings calendar and historical EPS data
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/_openbb_common.sh"
+
 
 if [ $# -lt 1 ]; then
     echo "Usage: openbb-earnings SYMBOL"
@@ -8,11 +14,7 @@ fi
 
 SYMBOL="$1"
 
-LIBSTDCXX=$(nix-build -E "with import <nixpkgs> {}; stdenv.cc.cc.lib" --no-out-link 2>/dev/null)/lib
-LIBZ=$(nix-build -E "with import <nixpkgs> {}; zlib" --no-out-link 2>/dev/null)/lib
-export LD_LIBRARY_PATH="$LIBSTDCXX:$LIBZ:${LD_LIBRARY_PATH:-}"
-
-/home/art/.local/venvs/openbb/bin/python3 << PYTHON
+run_openbb_python_with_retry << PYTHON
 from openbb import obb
 import json
 import sys

--- a/scripts/openbb-estimates
+++ b/scripts/openbb-estimates
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 # OpenBB analyst estimates and price targets
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/_openbb_common.sh"
+
 
 if [ $# -lt 1 ]; then
     echo "Usage: openbb-estimates SYMBOL"
@@ -8,11 +14,7 @@ fi
 
 SYMBOL="$1"
 
-LIBSTDCXX=$(nix-build -E "with import <nixpkgs> {}; stdenv.cc.cc.lib" --no-out-link 2>/dev/null)/lib
-LIBZ=$(nix-build -E "with import <nixpkgs> {}; zlib" --no-out-link 2>/dev/null)/lib
-export LD_LIBRARY_PATH="$LIBSTDCXX:$LIBZ:${LD_LIBRARY_PATH:-}"
-
-/home/art/.local/venvs/openbb/bin/python3 << PYTHON
+run_openbb_python_with_retry << PYTHON
 from openbb import obb
 import json
 import sys

--- a/scripts/openbb-ev-ntm
+++ b/scripts/openbb-ev-ntm
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 # OpenBB EV/NTM Revenue calculator
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/_openbb_common.sh"
+
 # Estimates NTM revenue from TTM × (1 + growth rate)
 
 if [ $# -lt 1 ]; then
@@ -9,11 +15,7 @@ fi
 
 SYMBOL="$1"
 
-LIBSTDCXX=$(nix-build -E "with import <nixpkgs> {}; stdenv.cc.cc.lib" --no-out-link 2>/dev/null)/lib
-LIBZ=$(nix-build -E "with import <nixpkgs> {}; zlib" --no-out-link 2>/dev/null)/lib
-export LD_LIBRARY_PATH="$LIBSTDCXX:$LIBZ:${LD_LIBRARY_PATH:-}"
-
-/home/art/.local/venvs/openbb/bin/python3 << PYSCRIPT
+run_openbb_python_with_retry << PYSCRIPT
 import json
 import sys
 from openbb import obb

--- a/scripts/openbb-financials
+++ b/scripts/openbb-financials
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 # OpenBB financial statements tool
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/_openbb_common.sh"
+
 
 if [ $# -lt 1 ]; then
     echo "Usage: openbb-financials SYMBOL [statement] [years]"
@@ -10,12 +16,8 @@ SYMBOL="$1"
 STATEMENT="${2:-income}"
 YEARS="${3:-5}"
 
-LIBSTDCXX=$(nix-build -E "with import <nixpkgs> {}; stdenv.cc.cc.lib" --no-out-link 2>/dev/null)/lib
-LIBZ=$(nix-build -E "with import <nixpkgs> {}; zlib" --no-out-link 2>/dev/null)/lib
-export LD_LIBRARY_PATH="$LIBSTDCXX:$LIBZ:${LD_LIBRARY_PATH:-}"
-
 # Write and execute Python script
-/home/art/.local/venvs/openbb/bin/python3 << PYSCRIPT
+run_openbb_python_with_retry << PYSCRIPT
 import os
 import sys
 import json

--- a/scripts/openbb-get-quote
+++ b/scripts/openbb-get-quote
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 # OpenBB simple single-ticker quote (Python alternative to openbb-quote)
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/_openbb_common.sh"
+
 
 if [ $# -lt 1 ]; then
     echo "Usage: openbb-get-quote SYMBOL [provider]"
@@ -9,11 +15,7 @@ fi
 SYMBOL="$1"
 PROVIDER="${2:-yfinance}"
 
-LIBSTDCXX=$(nix-build -E "with import <nixpkgs> {}; stdenv.cc.cc.lib" --no-out-link 2>/dev/null)/lib
-LIBZ=$(nix-build -E "with import <nixpkgs> {}; zlib" --no-out-link 2>/dev/null)/lib
-export LD_LIBRARY_PATH="$LIBSTDCXX:$LIBZ:${LD_LIBRARY_PATH:-}"
-
-/home/art/.local/venvs/openbb/bin/python3 << PYTHON
+run_openbb_python_with_retry << PYTHON
 from openbb import obb
 import json
 import sys

--- a/scripts/openbb-growth-profile
+++ b/scripts/openbb-growth-profile
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 # OpenBB growth profile tool - comprehensive growth metrics
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/_openbb_common.sh"
+
 
 if [ $# -lt 1 ]; then
     echo "Usage: openbb-growth-profile SYMBOL"
@@ -7,11 +13,7 @@ if [ $# -lt 1 ]; then
 fi
 
 export SYMBOL="$1"
-LIBSTDCXX=$(nix-build -E "with import <nixpkgs> {}; stdenv.cc.cc.lib" --no-out-link 2>/dev/null)/lib
-LIBZ=$(nix-build -E "with import <nixpkgs> {}; zlib" --no-out-link 2>/dev/null)/lib
-export LD_LIBRARY_PATH="$LIBSTDCXX:$LIBZ:${LD_LIBRARY_PATH:-}"
-
-/home/art/.local/venvs/openbb/bin/python3 << 'PYEOF'
+run_openbb_python_with_retry << 'PYEOF'
 import os
 import sys
 import json

--- a/scripts/openbb-historical
+++ b/scripts/openbb-historical
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 # OpenBB historical performance tool for clawdbot
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/_openbb_common.sh"
+
 
 if [ $# -lt 1 ]; then
     echo "Usage: openbb-historical SYMBOL [period]"
@@ -11,12 +17,8 @@ SYMBOL="$1"
 PERIOD="${2:-1y}"
 
 # Set library path for NixOS
-LIBSTDCXX=$(nix-build -E "with import <nixpkgs> {}; stdenv.cc.cc.lib" --no-out-link 2>/dev/null)/lib
-LIBZ=$(nix-build -E "with import <nixpkgs> {}; zlib" --no-out-link 2>/dev/null)/lib
-export LD_LIBRARY_PATH="$LIBSTDCXX:$LIBZ:${LD_LIBRARY_PATH:-}"
-
 # Use venv's python directly - calculate dates in Python
-/home/art/.local/venvs/openbb/bin/python3 << PYTHON
+run_openbb_python_with_retry << PYTHON
 from openbb import obb
 import json
 from datetime import datetime, timedelta

--- a/scripts/openbb-metrics
+++ b/scripts/openbb-metrics
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 # OpenBB key metrics tool - P/E, margins, ROE, EPS, etc.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/_openbb_common.sh"
+
 
 if [ $# -lt 1 ]; then
     echo "Usage: openbb-metrics SYMBOL"
@@ -9,12 +15,8 @@ fi
 SYMBOL="$1"
 
 # Set library path for NixOS
-LIBSTDCXX=$(nix-build -E "with import <nixpkgs> {}; stdenv.cc.cc.lib" --no-out-link 2>/dev/null)/lib
-LIBZ=$(nix-build -E "with import <nixpkgs> {}; zlib" --no-out-link 2>/dev/null)/lib
-export LD_LIBRARY_PATH="$LIBSTDCXX:$LIBZ:${LD_LIBRARY_PATH:-}"
-
 # Use venv's python directly
-/home/art/.local/venvs/openbb/bin/python3 << PYTHON
+run_openbb_python_with_retry << PYTHON
 from openbb import obb
 import json
 

--- a/scripts/openbb-ownership
+++ b/scripts/openbb-ownership
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 # OpenBB institutional/insider ownership data
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/_openbb_common.sh"
+
 
 if [ $# -lt 1 ]; then
     echo "Usage: openbb-ownership SYMBOL"
@@ -8,11 +14,7 @@ fi
 
 SYMBOL="$1"
 
-LIBSTDCXX=$(nix-build -E "with import <nixpkgs> {}; stdenv.cc.cc.lib" --no-out-link 2>/dev/null)/lib
-LIBZ=$(nix-build -E "with import <nixpkgs> {}; zlib" --no-out-link 2>/dev/null)/lib
-export LD_LIBRARY_PATH="$LIBSTDCXX:$LIBZ:${LD_LIBRARY_PATH:-}"
-
-/home/art/.local/venvs/openbb/bin/python3 << PYTHON
+run_openbb_python_with_retry << PYTHON
 from openbb import obb
 import json
 import sys

--- a/scripts/openbb-profile
+++ b/scripts/openbb-profile
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 # OpenBB company profile tool - sector, industry, description, etc.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/_openbb_common.sh"
+
 
 if [ $# -lt 1 ]; then
     echo "Usage: openbb-profile SYMBOL"
@@ -9,12 +15,8 @@ fi
 SYMBOL="$1"
 
 # Set library path for NixOS
-LIBSTDCXX=$(nix-build -E "with import <nixpkgs> {}; stdenv.cc.cc.lib" --no-out-link 2>/dev/null)/lib
-LIBZ=$(nix-build -E "with import <nixpkgs> {}; zlib" --no-out-link 2>/dev/null)/lib
-export LD_LIBRARY_PATH="$LIBSTDCXX:$LIBZ:${LD_LIBRARY_PATH:-}"
-
 # Use venv's python directly
-/home/art/.local/venvs/openbb/bin/python3 << PYTHON
+run_openbb_python_with_retry << PYTHON
 from openbb import obb
 import json
 

--- a/scripts/openbb-quality
+++ b/scripts/openbb-quality
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 # OpenBB quality scoring tool
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/_openbb_common.sh"
+
 
 if [ $# -lt 1 ]; then
     echo "Usage: openbb-quality SYMBOL"
@@ -7,11 +13,7 @@ if [ $# -lt 1 ]; then
 fi
 
 export SYMBOL="$1"
-LIBSTDCXX=$(nix-build -E "with import <nixpkgs> {}; stdenv.cc.cc.lib" --no-out-link 2>/dev/null)/lib
-LIBZ=$(nix-build -E "with import <nixpkgs> {}; zlib" --no-out-link 2>/dev/null)/lib
-export LD_LIBRARY_PATH="$LIBSTDCXX:$LIBZ:${LD_LIBRARY_PATH:-}"
-
-/home/art/.local/venvs/openbb/bin/python3 << 'PYEOF'
+run_openbb_python_with_retry << 'PYEOF'
 import os
 import sys
 import json

--- a/scripts/openbb-quote
+++ b/scripts/openbb-quote
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
 # OpenBB stock quote wrapper for clawdbot (NixOS-compatible) - Multi-ticker support
-
 set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/_openbb_common.sh"
 
 if [ $# -lt 1 ]; then
     echo "Usage: openbb-quote SYMBOL [SYMBOL2 ...] [provider]"
@@ -9,11 +12,6 @@ if [ $# -lt 1 ]; then
 fi
 
 # Set library path for NixOS
-LIBSTDCXX=$(nix-build -E "with import <nixpkgs> {}; stdenv.cc.cc.lib" --no-out-link 2>/dev/null)/lib
-LIBZ=$(nix-build -E "with import <nixpkgs> {}; zlib" --no-out-link 2>/dev/null)/lib
-export LD_LIBRARY_PATH="$LIBSTDCXX:$LIBZ:${LD_LIBRARY_PATH:-}"
-export ALPHAVANTAGE_API_KEY="${ALPHAVANTAGE_API_KEY:-0QQ0NV9R8E5I28UI}"
-
 # Detect provider: if last arg is a valid provider, use it
 PROVIDER="yfinance"
 TICKERS=()
@@ -33,21 +31,7 @@ done
 export _OPENBB_PROVIDER="$PROVIDER"
 export _OPENBB_TICKERS="$(printf '%s\n' "${TICKERS[@]}")"
 
-# Retry knobs (handles transient OpenBB package build lock contention)
-MAX_ATTEMPTS="${OPENBB_RETRY_MAX_ATTEMPTS:-6}"
-BASE_DELAY_SEC="${OPENBB_RETRY_BASE_DELAY_SEC:-2}"
-
-is_lock_contention() {
-    local text="$1"
-    [[ "$text" == *".build.lock"* ]] \
-        || [[ "$text" == *"Another build process is running"* ]] \
-        || [[ "$text" == *"BlockingIOError"* ]] \
-        || [[ "$text" == *"Resource temporarily unavailable"* ]]
-}
-
-run_openbb_quote_once() {
-    # Use venv's python with full OpenBB SDK
-    /home/art/.local/venvs/openbb/bin/python3 << 'PYTHON'
+run_openbb_python_with_retry << 'PYTHON'
 from openbb import obb
 import json
 import os
@@ -79,40 +63,3 @@ for symbol in TICKERS:
 
 print(json.dumps(results, indent=2))
 PYTHON
-}
-
-attempt=1
-while true; do
-    output=""
-    status=0
-
-    if output="$(run_openbb_quote_once 2>&1)"; then
-        status=0
-    else
-        status=$?
-    fi
-
-    if [ "$status" -eq 0 ]; then
-        printf "%s\n" "$output"
-        exit 0
-    fi
-
-    if is_lock_contention "$output"; then
-        if [ "$attempt" -ge "$MAX_ATTEMPTS" ]; then
-            {
-                echo "openbb-quote failed after ${MAX_ATTEMPTS} lock-contention retries."
-                echo "$output"
-            } >&2
-            exit "$status"
-        fi
-
-        delay=$((BASE_DELAY_SEC * (2 ** (attempt - 1))))
-        echo "openbb-quote: build lock detected, retry ${attempt}/${MAX_ATTEMPTS} in ${delay}s..." >&2
-        sleep "$delay"
-        attempt=$((attempt + 1))
-        continue
-    fi
-
-    printf "%s\n" "$output" >&2
-    exit "$status"
-done

--- a/scripts/openbb-ratios
+++ b/scripts/openbb-ratios
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 # OpenBB financial ratios tool
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/_openbb_common.sh"
+
 
 if [ $# -lt 1 ]; then
     echo "Usage: openbb-ratios SYMBOL"
@@ -7,11 +13,7 @@ if [ $# -lt 1 ]; then
 fi
 
 SYMBOL="$1"
-LIBSTDCXX=$(nix-build -E "with import <nixpkgs> {}; stdenv.cc.cc.lib" --no-out-link 2>/dev/null)/lib
-LIBZ=$(nix-build -E "with import <nixpkgs> {}; zlib" --no-out-link 2>/dev/null)/lib
-export LD_LIBRARY_PATH="$LIBSTDCXX:$LIBZ:${LD_LIBRARY_PATH:-}"
-
-/home/art/.local/venvs/openbb/bin/python3 << PYTHON
+run_openbb_python_with_retry << PYTHON
 from openbb import obb
 import json
 import sys

--- a/scripts/openbb-technicals
+++ b/scripts/openbb-technicals
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 # OpenBB technical indicators (50/200 DMA, Death Cross detection)
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/_openbb_common.sh"
+
 
 if [ $# -lt 1 ]; then
     echo "Usage: openbb-technicals SYMBOL"
@@ -8,11 +14,7 @@ fi
 
 SYMBOL="$1"
 
-LIBSTDCXX=$(nix-build -E "with import <nixpkgs> {}; stdenv.cc.cc.lib" --no-out-link 2>/dev/null)/lib
-LIBZ=$(nix-build -E "with import <nixpkgs> {}; zlib" --no-out-link 2>/dev/null)/lib
-export LD_LIBRARY_PATH="$LIBSTDCXX:$LIBZ:${LD_LIBRARY_PATH:-}"
-
-/home/art/.local/venvs/openbb/bin/python3 << PYSCRIPT
+run_openbb_python_with_retry << PYSCRIPT
 import json
 import sys
 from datetime import datetime, timedelta

--- a/scripts/openbb-valuation
+++ b/scripts/openbb-valuation
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 # OpenBB valuation tool - multiple valuation methods
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/_openbb_common.sh"
+
 
 if [ $# -lt 1 ]; then
     echo "Usage: openbb-valuation SYMBOL"
@@ -7,11 +13,7 @@ if [ $# -lt 1 ]; then
 fi
 
 export SYMBOL="$1"
-LIBSTDCXX=$(nix-build -E "with import <nixpkgs> {}; stdenv.cc.cc.lib" --no-out-link 2>/dev/null)/lib
-LIBZ=$(nix-build -E "with import <nixpkgs> {}; zlib" --no-out-link 2>/dev/null)/lib
-export LD_LIBRARY_PATH="$LIBSTDCXX:$LIBZ:${LD_LIBRARY_PATH:-}"
-
-/home/art/.local/venvs/openbb/bin/python3 << 'PYEOF'
+run_openbb_python_with_retry << 'PYEOF'
 import os
 import sys
 import json

--- a/scripts/openbb-volatility
+++ b/scripts/openbb-volatility
@@ -1,5 +1,11 @@
 #!/usr/bin/env bash
 # OpenBB volatility and risk metrics tool
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/_openbb_common.sh"
+
 
 if [ $# -lt 1 ]; then
     echo "Usage: openbb-volatility SYMBOL"
@@ -7,11 +13,7 @@ if [ $# -lt 1 ]; then
 fi
 
 export SYMBOL="$1"
-LIBSTDCXX=$(nix-build -E "with import <nixpkgs> {}; stdenv.cc.cc.lib" --no-out-link 2>/dev/null)/lib
-LIBZ=$(nix-build -E "with import <nixpkgs> {}; zlib" --no-out-link 2>/dev/null)/lib
-export LD_LIBRARY_PATH="$LIBSTDCXX:$LIBZ:${LD_LIBRARY_PATH:-}"
-
-/home/art/.local/venvs/openbb/bin/python3 << 'PYEOF'
+run_openbb_python_with_retry << 'PYEOF'
 import os
 import sys
 import json


### PR DESCRIPTION
## Summary
- add `scripts/_openbb_common.sh` with shared helpers for:
  - python runtime resolution (`OPENBB_PYTHON` override, venv fallback, system fallback)
  - Nix `LD_LIBRARY_PATH` setup
  - lock-contention retry handling
- migrate all `scripts/openbb-*` wrappers to use shared helper
- remove hardcoded python path and duplicated runtime boilerplate from wrappers
- simplify `openbb-quote` to rely on shared retry implementation (single retry layer)

## Why
- consistent failure/retry behavior across wrappers
- easier maintenance (single source of truth)
- removes host-specific hardcoding in each script

## Validation
- `bash -n scripts/_openbb_common.sh scripts/openbb-*`
- full smoke pass:
  - `scripts/openbb-quote AAPL`
  - `scripts/openbb-get-quote MSFT`
  - `scripts/openbb-ratios NVDA`
  - `scripts/openbb-financials AMD income 2`
  - `scripts/openbb-earnings GOOGL`
  - `scripts/openbb-estimates AMZN`
  - `scripts/openbb-ev-ntm META`
  - `scripts/openbb-growth-profile NFLX`
  - `scripts/openbb-historical TSLA 1y`
  - `scripts/openbb-metrics KO`
  - `scripts/openbb-ownership AAPL`
  - `scripts/openbb-profile BRK-B`
  - `scripts/openbb-quality COST`
  - `scripts/openbb-technicals AAPL`
  - `scripts/openbb-valuation MSFT`
  - `scripts/openbb-volatility QQQ`
  - `scripts/openbb-dividend JNJ`
