### PR TITLE
fix(openbb): support symlinked wrapper invocation

### DIFF
--- a/scripts/openbb-dividend
+++ b/scripts/openbb-dividend
@@ -2,7 +2,7 @@
 # OpenBB dividend analysis tool
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd)"
 # shellcheck source=/dev/null
 source "$SCRIPT_DIR/_openbb_common.sh"
 

--- a/scripts/openbb-earnings
+++ b/scripts/openbb-earnings
@@ -2,7 +2,7 @@
 # OpenBB earnings calendar and historical EPS data
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd)"
 # shellcheck source=/dev/null
 source "$SCRIPT_DIR/_openbb_common.sh"
 

--- a/scripts/openbb-estimates
+++ b/scripts/openbb-estimates
@@ -2,7 +2,7 @@
 # OpenBB analyst estimates and price targets
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd)"
 # shellcheck source=/dev/null
 source "$SCRIPT_DIR/_openbb_common.sh"
 

--- a/scripts/openbb-ev-ntm
+++ b/scripts/openbb-ev-ntm
@@ -2,7 +2,7 @@
 # OpenBB EV/NTM Revenue calculator
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd)"
 # shellcheck source=/dev/null
 source "$SCRIPT_DIR/_openbb_common.sh"
 

--- a/scripts/openbb-financials
+++ b/scripts/openbb-financials
@@ -2,7 +2,7 @@
 # OpenBB financial statements tool
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd)"
 # shellcheck source=/dev/null
 source "$SCRIPT_DIR/_openbb_common.sh"
 

--- a/scripts/openbb-get-quote
+++ b/scripts/openbb-get-quote
@@ -2,7 +2,7 @@
 # OpenBB simple single-ticker quote (Python alternative to openbb-quote)
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd)"
 # shellcheck source=/dev/null
 source "$SCRIPT_DIR/_openbb_common.sh"
 

--- a/scripts/openbb-growth-profile
+++ b/scripts/openbb-growth-profile
@@ -2,7 +2,7 @@
 # OpenBB growth profile tool - comprehensive growth metrics
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd)"
 # shellcheck source=/dev/null
 source "$SCRIPT_DIR/_openbb_common.sh"
 

--- a/scripts/openbb-historical
+++ b/scripts/openbb-historical
@@ -2,7 +2,7 @@
 # OpenBB historical performance tool for clawdbot
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd)"
 # shellcheck source=/dev/null
 source "$SCRIPT_DIR/_openbb_common.sh"
 

--- a/scripts/openbb-metrics
+++ b/scripts/openbb-metrics
@@ -2,7 +2,7 @@
 # OpenBB key metrics tool - P/E, margins, ROE, EPS, etc.
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd)"
 # shellcheck source=/dev/null
 source "$SCRIPT_DIR/_openbb_common.sh"
 

--- a/scripts/openbb-ownership
+++ b/scripts/openbb-ownership
@@ -2,7 +2,7 @@
 # OpenBB institutional/insider ownership data
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd)"
 # shellcheck source=/dev/null
 source "$SCRIPT_DIR/_openbb_common.sh"
 

--- a/scripts/openbb-profile
+++ b/scripts/openbb-profile
@@ -2,7 +2,7 @@
 # OpenBB company profile tool - sector, industry, description, etc.
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd)"
 # shellcheck source=/dev/null
 source "$SCRIPT_DIR/_openbb_common.sh"
 

--- a/scripts/openbb-quality
+++ b/scripts/openbb-quality
@@ -2,7 +2,7 @@
 # OpenBB quality scoring tool
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd)"
 # shellcheck source=/dev/null
 source "$SCRIPT_DIR/_openbb_common.sh"
 

--- a/scripts/openbb-quote
+++ b/scripts/openbb-quote
@@ -2,7 +2,7 @@
 # OpenBB stock quote wrapper for clawdbot (NixOS-compatible) - Multi-ticker support
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd)"
 # shellcheck source=/dev/null
 source "$SCRIPT_DIR/_openbb_common.sh"
 

--- a/scripts/openbb-ratios
+++ b/scripts/openbb-ratios
@@ -2,7 +2,7 @@
 # OpenBB financial ratios tool
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd)"
 # shellcheck source=/dev/null
 source "$SCRIPT_DIR/_openbb_common.sh"
 

--- a/scripts/openbb-technicals
+++ b/scripts/openbb-technicals
@@ -2,7 +2,7 @@
 # OpenBB technical indicators (50/200 DMA, Death Cross detection)
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd)"
 # shellcheck source=/dev/null
 source "$SCRIPT_DIR/_openbb_common.sh"
 

--- a/scripts/openbb-valuation
+++ b/scripts/openbb-valuation
@@ -2,7 +2,7 @@
 # OpenBB valuation tool - multiple valuation methods
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd)"
 # shellcheck source=/dev/null
 source "$SCRIPT_DIR/_openbb_common.sh"
 

--- a/scripts/openbb-volatility
+++ b/scripts/openbb-volatility
@@ -2,7 +2,7 @@
 # OpenBB volatility and risk metrics tool
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd)"
 # shellcheck source=/dev/null
 source "$SCRIPT_DIR/_openbb_common.sh"
 


### PR DESCRIPTION
## Summary
- fix helper path resolution in all `openbb-*` wrappers by resolving script directory via real path:
  - from `dirname "${BASH_SOURCE[0]}"`
  - to `dirname "$(readlink -f "${BASH_SOURCE[0]}")"`
- this ensures `_openbb_common.sh` is found when wrappers are invoked through symlinks (e.g. `~/.local/bin/openbb-quote`)

## Why
Current user setup relies on symlinked executables in `~/.local/bin`. Those wrappers were resolving helper path relative to the symlink location, which failed with:

`/home/art/.local/bin/openbb-quote: line 7: /home/art/.local/bin/_openbb_common.sh: No such file or directory`

## Validation
- `bash -n scripts/openbb-*`
- `/home/art/.local/bin/openbb-quote AAPL`
- `openbb-quote MSFT`
