### PR TITLE
feat(openbb): add explicit CLI fallback path

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,13 @@ ln -s /path/to/openbb-cli-tools-openclaw-skill ~/.openclaw/skills/openbb
 | `openbb-estimates` | Analyst targets, recommendations | yfinance (falls back to fmp) |
 | `openbb-earnings` | Next earnings + EPS history | yfinance + FMP |
 | `openbb-ownership` | Institutional ownership | fmp (falls back to intrinio, sec) |
+| `openbb-cli-fallback` | Raw OpenBB CLI passthrough for uncovered endpoints | OpenBB CLI |
+
+## Command Policy
+
+1. Use `openbb-*` wrappers first for automation and stable JSON contracts.
+2. Use `openbb-cli-fallback` only when wrappers do not cover the requested endpoint/workflow.
+3. If fallback usage repeats, promote it into a new dedicated wrapper.
 
 ## Usage
 
@@ -59,6 +66,11 @@ Multiple tickers:
 Specify provider:
 ```bash
 ./scripts/openbb-quote AAPL fmp
+```
+
+CLI fallback:
+```bash
+./scripts/openbb-cli-fallback --file ./my-routine.openbb
 ```
 
 ## Data Providers

--- a/SKILL.md
+++ b/SKILL.md
@@ -29,6 +29,13 @@ Fetch stock market data using OpenBB SDK CLI wrappers. All output is JSON.
 | `openbb-ev-ntm` | EV/NTM revenue | `openbb-ev-ntm CRM` |
 | `openbb-profile` | Company info | `openbb-profile DIS` |
 | `openbb-ownership` | Institutional ownership | `openbb-ownership AAPL` |
+| `openbb-cli-fallback` | Raw OpenBB CLI passthrough for uncovered cases | `openbb-cli-fallback --help` |
+
+## Command Selection Policy
+
+1. Use wrapper scripts first (`openbb-quote`, `openbb-ratios`, etc.).
+2. Use `openbb-cli-fallback` only if wrappers do not cover the requested endpoint/workflow.
+3. Treat CLI output as non-stable text output unless you explicitly control the routine and output format.
 
 ## Usage Patterns
 
@@ -60,6 +67,12 @@ Fetch stock market data using OpenBB SDK CLI wrappers. All output is JSON.
 
 # Cash flow statement, 3 years  
 <skill>/scripts/openbb-financials AAPL cash 3
+```
+
+### CLI Fallback (Uncovered Endpoints)
+```bash
+# Run a routine file through OpenBB CLI
+<skill>/scripts/openbb-cli-fallback --file ./my-routine.openbb
 ```
 
 ## Data Providers
@@ -135,6 +148,8 @@ User: "Is NVDA overvalued?"
 **Empty results:** Some endpoints need paid FMP subscription. Check the "Data Providers" section.
 
 **Timeout:** Some queries are slow on first run (SDK initialization). Retry usually works.
+
+**Need an endpoint not covered by wrappers:** Use `openbb-cli-fallback --file <routine.openbb>` as temporary fallback, then add a dedicated wrapper for repeat usage.
 
 **OpenBB build lock contention (`.build.lock`):**
 - `openbb-quote` now retries automatically with exponential backoff when another OpenBB process is building extensions.

--- a/scripts/openbb-cli-fallback
+++ b/scripts/openbb-cli-fallback
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# OpenBB CLI fallback for capabilities not covered by wrapper scripts.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" && pwd)"
+# shellcheck source=/dev/null
+source "$SCRIPT_DIR/_openbb_common.sh"
+
+usage() {
+    cat <<'EOF'
+Usage:
+  openbb-cli-fallback --file ROUTINE.openbb
+  openbb-cli-fallback --help
+  openbb-cli-fallback --version
+
+Notes:
+  - Wrapper scripts (openbb-quote, openbb-ratios, etc.) should be used first.
+  - Use this command only when wrappers do not cover the requested endpoint/workflow.
+  - CLI output format can vary; do not treat it as a stable machine interface.
+
+Env:
+  OPENBB_CLI_BIN          Override CLI binary path (default: ~/.local/bin/openbb)
+  OPENBB_CLI_TIMEOUT_SEC  Timeout in seconds (default: 180)
+EOF
+}
+
+if [[ $# -lt 1 ]]; then
+    usage >&2
+    exit 1
+fi
+
+setup_openbb_ld_library_path
+
+OPENBB_CLI_BIN="${OPENBB_CLI_BIN:-$HOME/.local/bin/openbb}"
+if [[ ! -x "$OPENBB_CLI_BIN" ]]; then
+    OPENBB_CLI_BIN="$HOME/.local/venvs/openbb/bin/openbb"
+fi
+if [[ ! -x "$OPENBB_CLI_BIN" ]]; then
+    echo "OpenBB CLI binary not found. Set OPENBB_CLI_BIN or install OpenBB CLI." >&2
+    exit 1
+fi
+
+TIMEOUT_SEC="${OPENBB_CLI_TIMEOUT_SEC:-180}"
+if command -v timeout >/dev/null 2>&1; then
+    timeout "$TIMEOUT_SEC" "$OPENBB_CLI_BIN" "$@"
+    exit $?
+fi
+
+"$OPENBB_CLI_BIN" "$@"


### PR DESCRIPTION
## Summary
- add `scripts/openbb-cli-fallback` as an explicit escape hatch for endpoints/workflows not yet covered by wrappers
- make policy explicit in docs:
  - wrappers first for stable JSON and automation
  - CLI fallback only for uncovered cases
  - promote repeated fallback usage into dedicated wrappers
- document fallback usage in both `SKILL.md` and `README.md`

## Why
Users asked for hybrid usage (wrapper + CLI). This keeps wrapper reliability while enabling broader OpenBB CLI surface area when needed.

## Validation
- `bash -n scripts/openbb-cli-fallback scripts/_openbb_common.sh`
- `scripts/openbb-cli-fallback --help`
- `scripts/openbb-cli-fallback --version`
- `scripts/openbb-cli-fallback` (no args -> usage, exit 1)
