### PR TITLE
fix(openbb): resolve CLI fallback binary from PATH

### DIFF
--- a/scripts/openbb-cli-fallback
+++ b/scripts/openbb-cli-fallback
@@ -19,7 +19,7 @@ Notes:
   - CLI output format can vary; do not treat it as a stable machine interface.
 
 Env:
-  OPENBB_CLI_BIN          Override CLI binary path (default: ~/.local/bin/openbb)
+  OPENBB_CLI_BIN          Override CLI binary path (default search: ~/.local/bin, ~/.local/venvs, PATH)
   OPENBB_CLI_TIMEOUT_SEC  Timeout in seconds (default: 180)
 EOF
 }
@@ -31,13 +31,22 @@ fi
 
 setup_openbb_ld_library_path
 
-OPENBB_CLI_BIN="${OPENBB_CLI_BIN:-$HOME/.local/bin/openbb}"
-if [[ ! -x "$OPENBB_CLI_BIN" ]]; then
-    OPENBB_CLI_BIN="$HOME/.local/venvs/openbb/bin/openbb"
-fi
-if [[ ! -x "$OPENBB_CLI_BIN" ]]; then
-    echo "OpenBB CLI binary not found. Set OPENBB_CLI_BIN or install OpenBB CLI." >&2
-    exit 1
+if [[ -n "${OPENBB_CLI_BIN:-}" ]]; then
+    if [[ ! -x "$OPENBB_CLI_BIN" ]]; then
+        echo "OPENBB_CLI_BIN is set but not executable: $OPENBB_CLI_BIN" >&2
+        exit 1
+    fi
+else
+    if [[ -x "$HOME/.local/bin/openbb" ]]; then
+        OPENBB_CLI_BIN="$HOME/.local/bin/openbb"
+    elif [[ -x "$HOME/.local/venvs/openbb/bin/openbb" ]]; then
+        OPENBB_CLI_BIN="$HOME/.local/venvs/openbb/bin/openbb"
+    elif command -v openbb >/dev/null 2>&1; then
+        OPENBB_CLI_BIN="$(command -v openbb)"
+    else
+        echo "OpenBB CLI binary not found. Set OPENBB_CLI_BIN or install OpenBB CLI." >&2
+        exit 1
+    fi
 fi
 
 TIMEOUT_SEC="${OPENBB_CLI_TIMEOUT_SEC:-180}"


### PR DESCRIPTION
## Summary
- fix `openbb-cli-fallback` binary resolution order
- if `OPENBB_CLI_BIN` is not set, search in this order:
  1. `~/.local/bin/openbb`
  2. `~/.local/venvs/openbb/bin/openbb`
  3. `command -v openbb` (PATH)
- if `OPENBB_CLI_BIN` is explicitly set, validate executability and fail with a clear error
- update usage text to reflect actual default search behavior

## Why
PR #10 fallback command only checked two hardcoded locations and could fail in valid environments where OpenBB is installed on PATH.

## Validation
- `bash -n scripts/openbb-cli-fallback`
- `scripts/openbb-cli-fallback --version`
- PATH resolution test with temporary `openbb` binary in PATH
