### PR TITLE
fix: add buybacks, dividends, and dilution fields to cash flow output

### DIFF
--- a/scripts/openbb-financials
+++ b/scripts/openbb-financials
@@ -103,6 +103,9 @@ def process_cash_flow(data, income_data=None):
         capex = extra.get('capital_expenditure')
         fcf = extra.get('free_cash_flow')
         sbc = extra.get('stock_based_compensation')
+        repurchase_of_capital_stock = extra.get('repurchase_of_capital_stock')
+        common_stock_dividend_paid = extra.get('common_stock_dividend_paid')
+        issuance_of_capital_stock = extra.get('issuance_of_capital_stock')
         
         # Calculate FCF if not directly available
         if fcf is None and operating_cf is not None and capex is not None:
@@ -114,6 +117,9 @@ def process_cash_flow(data, income_data=None):
             "capital_expenditure": capex,
             "free_cash_flow": fcf,
             "stock_based_compensation": sbc,
+            "repurchase_of_capital_stock": repurchase_of_capital_stock,
+            "common_stock_dividend_paid": common_stock_dividend_paid,
+            "issuance_of_capital_stock": issuance_of_capital_stock,
         }
         
         # Calculate margins if we have revenue


### PR DESCRIPTION
## Issue #15

`process_cash_flow()` in `openbb-financials` only extracted 4 fields from yfinance `model_extra`, missing 3 critical fields for shareholder yield analysis.

### Added
- `repurchase_of_capital_stock` — share buybacks (negative = cash out)
- `common_stock_dividend_paid` — dividend payments (negative = cash out)  
- `issuance_of_capital_stock` — stock issuance/dilution (positive = cash in)

### Impact
Downstream consumers (equity-research UQF) can now compute accurate shareholder yield for US tickers. Previously all US tickers showed buybacks=0 and dividends=0 from cash flow data.

### Implementation
Used Codex CLI via tmux. 6 lines added, follows existing extraction pattern.

Closes #15
Related: kesslerio/equity-research-openclaw-skill#184